### PR TITLE
Use shiftwidth function instead of setting

### DIFF
--- a/plugin/vip.vim
+++ b/plugin/vip.vim
@@ -510,7 +510,7 @@ if &expandtab == 1
 else
   let s:indChar = "\t"
 endif
-for s:inc in range(2, &shiftwidth)
+for s:inc in range(2, shiftwidth())
   let s:indChar = s:indChar.s:indChar
 endfor
 

--- a/plugin/vip.vim
+++ b/plugin/vip.vim
@@ -510,7 +510,7 @@ if &expandtab == 1
 else
   let s:indChar = "\t"
 endif
-for s:inc in range(2, shiftwidth())
+for s:inc in range(2, (exists('?shiftwidth') ? shiftwidth() : &shiftwidth))
   let s:indChar = s:indChar.s:indChar
 endfor
 


### PR DESCRIPTION
Since Vim 7.3.694, the `shiftwidth` setting can be set to 0 to indicate that it should be the same as `tabstop`.
To get the correct value, Vim provides the `shiftwidth()` function, which should be used instead of reading the setting directly.